### PR TITLE
Use language locale if the locale file does not exist

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -34,7 +34,13 @@ module I18n
             default(locale, key, default, options) : resolve(locale, key, entry, options)
         end
 
-        throw(:exception, I18n::MissingTranslation.new(locale, key, options)) if entry.nil?
+        if entry.nil?
+          if locale =~ /^(\w+)\-\w+$/
+            return translate($1, key, options)
+          else
+            throw(:exception, I18n::MissingTranslation.new(locale, key, options))
+          end
+        end
         entry = entry.dup if entry.is_a?(String)
 
         entry = pluralize(locale, entry, count) if count

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -141,6 +141,15 @@ class I18nTest < Test::Unit::TestCase
     I18n.translate :foo, :locale => 'de'
   end
 
+  test "delegates translate calls to the backend with language locale" do
+    I18n.backend.store_translations 'en', 'foo' => {'bar' => 'bar'}
+    assert_equal 'bar', I18n.t('foo.bar', :locale => 'en-US')
+  end
+
+  test "return translation missing if language locale data is not exist" do
+    assert_equal 'translation missing: en.foo.bar', I18n.t('foo.bar', :locale => 'en-US')
+  end
+
   test "delegates localize calls to the backend" do
     I18n.backend.expects(:localize).with('de', :whatever, :default, {})
     I18n.localize :whatever, :locale => 'de'


### PR DESCRIPTION
When we use locale like a `en-US`, `en-GB`, we get translation missing if `en-us.yml` or `en-gb.yml` is not exist.

before

```
If locale is en-US:
  -> *translation missing* if en-us.yml is not exist.

If locale is en-GB:
  -> *translation missing* if en-gb.yml is not exist.
```

I think this is better.

after

```
If locale is en-US:
  -> *check* en.yml if en-us.yml is not exist.
  -> *translation missing* if en.yml is not exist.

If locale is en-GB:
  -> *check* en.yml if en-gb.yml is not exist.
  -> *translation missing* if en.yml is not exist.
```
